### PR TITLE
bootstrap5 row/col support for collection fields

### DIFF
--- a/src/Resources/views/crud/form_theme.html.twig
+++ b/src/Resources/views/crud/form_theme.html.twig
@@ -206,7 +206,9 @@
                 </h2>
                 <div id="{{ id }}-contents" class="accordion-collapse collapse {{ render_expanded ? 'show' }}">
                     <div class="accordion-body">
-                        {{ form_widget(form) }}
+                        <div class="row">
+                            {{ form_widget(form) }}
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Solves issue #5895:  Allow bootstrap5 row/col support for collection fields using setEntryCrudForm()

